### PR TITLE
Bugfix 過去足データ取得時にbybitからのみ取得するようになっていたため修正

### DIFF
--- a/src/Common/src/ReflectableEnum.cs
+++ b/src/Common/src/ReflectableEnum.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+
+namespace BotTrade;
+
+[AttributeUsage(AttributeTargets.Field)]
+public sealed class ReflectableEnumAttribute : Attribute
+{
+    public Type ReflectableType { get; init; }
+    public IEnumerable<Type> ArgTypes { get; init; }
+
+    public ReflectableEnumAttribute(Type reflectableType, params Type[]? argTypes)
+    {
+        ReflectableType = reflectableType;
+        ArgTypes = argTypes ?? [];
+    }
+
+    public ReflectableEnumAttribute(string typeName, params Type[]? argTypes)
+    {
+        ReflectableType = Type.GetType(typeName, true) ?? typeof(object);
+        ArgTypes = argTypes ?? [];
+    }
+
+    public ReflectableEnumAttribute(string assemblyName, string typeName, params Type[]? argTypes)
+    {
+        var assembly = Assembly.Load(assemblyName);
+        ReflectableType = assembly.GetType(typeName, true) ?? typeof(object);
+        ArgTypes = argTypes ?? [];
+    }
+}
+
+public static class ReflectableEnum
+{
+    public static T? Reflection<T>(this Enum value, params object?[] args) where T : class
+    {
+        var type = value.GetType();
+        var fieldInfo = type.GetField(Enum.GetName(type, value) ?? string.Empty);
+        var attributes = fieldInfo?.GetCustomAttributes(typeof(ReflectableEnumAttribute), false);
+
+        if (attributes?.FirstOrDefault() is not ReflectableEnumAttribute attribute)
+            return null;
+
+        var constructor = attribute.ReflectableType.GetConstructor(attribute.ArgTypes.ToArray());
+        return constructor?.Invoke(args) as T;
+    }
+}

--- a/src/Domain/src/ExchangePlace.cs
+++ b/src/Domain/src/ExchangePlace.cs
@@ -1,13 +1,23 @@
 namespace BotTrade.Domain;
 
+/// <summary>
+/// 対象取引所Enum
+/// </summary>
+/// <remarks>
+/// フォワードテスト用の取引所をは<c>Testnet</c>を付ける
+/// </remarks>
 public enum ExchangePlace
 {
+    [ReflectableEnum("ccxt", "ccxt.Bybit", typeof(object))]
     [EnumString("Bybit")]
     Bybit,
-    [EnumString("BybitTestnet")]
+    [ReflectableEnum("ccxt", "ccxt.Bybit", typeof(object))]
+    [EnumString("Bybit")]
     BybitTestnet,
+    [ReflectableEnum("ccxt", "ccxt.Binance", typeof(object))]
     [EnumString("Binance")]
     Binance,
-    [EnumString("BinanceTestnet")]
+    [ReflectableEnum("ccxt", "ccxt.Binance", typeof(object))]
+    [EnumString("Binance")]
     BinanceTestnet,
 }

--- a/src/Domain/src/Strategies/Strategy.cs
+++ b/src/Domain/src/Strategies/Strategy.cs
@@ -24,11 +24,12 @@ public abstract class Strategy
 
     public static Strategy FromSetting(Setting.Strategy setting)
     {
-        return setting.Kind switch
+        if (setting.Kind.Reflection<Strategy>(setting.Timeframe, setting.Parameters) is not Strategy strategy)
         {
-            StrategyKind.MACross => new MACross(setting.Timeframe, setting.Parameters),
-            _ => throw new ArgumentException("未対応の戦略", nameof(setting.Kind)),
-        };
+            throw new ArgumentException("生成できない戦略", nameof(setting));
+        }
+
+        return strategy;
     }
 
     public override string ToString()

--- a/src/Domain/src/Strategies/StrategyKind.cs
+++ b/src/Domain/src/Strategies/StrategyKind.cs
@@ -1,7 +1,12 @@
 namespace BotTrade.Domain.Strategies;
 
+/// <summary>
+/// 設定ファイルで使用する定義済み戦略のEnum
+/// </summary>
 public enum StrategyKind
 {
-    [EnumString("MACross")]
+    [ReflectableEnum(
+        typeof(MACross),
+        [typeof(Timeframe), typeof(IEnumerable<int>)])]
     MACross,
 }

--- a/src/Infra/src/BotFactory.cs
+++ b/src/Infra/src/BotFactory.cs
@@ -27,26 +27,14 @@ public class BotFactory
     /// <param name="settings"></param>
     public BotFactory(IEnumerable<Setting.API> settings)
     {
-        ExchangeMap = settings.Select(api =>
+        ExchangeMap = new Dictionary<ExchangePlace, Exchange>();
+        foreach (var api in settings)
         {
-            ccxt.Exchange value;
-            switch (api.Place)
-            {
-                case ExchangePlace.Bybit:
-                case ExchangePlace.BybitTestnet:
-                    {
-                        value = new Bybit() { apiKey = api.Key, secret = api.Secret };
-                        if (api.Place == ExchangePlace.BybitTestnet)
-                            value.setSandboxMode(true);
-                        break;
-                    }
-                default:
-                    {
-                        throw new ArgumentException("未対応の取引所", nameof(api.Place));
-                    }
-            }
-            return new KeyValuePair<ExchangePlace, ccxt.Exchange>(api.Place, value);
-        }).ToDictionary();
+            var exchange = api.Place.Reflection<Exchange>([null]);
+            if (exchange == null)
+                continue;
+            ExchangeMap.Add(api.Place, exchange);
+        }
     }
 
     /// <summary>

--- a/src/Infra/src/PastCandelRepository.cs
+++ b/src/Infra/src/PastCandelRepository.cs
@@ -12,6 +12,7 @@ public class PastCandleRepository : IUpdatableCandleRepository, IDisposable
 {
     private const string TABLE_NAME = "candles";
     private Symbol Symbol { get; init; }
+    private ExchangePlace Place { get; init; }
     private SqliteConnection Connection { get; init; }
     private ILogger<PastCandleRepository> Logger { get; init; }
 
@@ -23,6 +24,7 @@ public class PastCandleRepository : IUpdatableCandleRepository, IDisposable
             DataSource = Path.GetFullPath(path),
         };
         Symbol = setting.Symbol;
+        Place = setting.Place;
         Logger = logger;
         Connection = new SqliteConnection(builder.ConnectionString);
         Connection.Open();
@@ -76,8 +78,8 @@ public class PastCandleRepository : IUpdatableCandleRepository, IDisposable
         {
             Logger.LogWarning("前回更新のデータが存在しないため、取引所から取得可能なデータをすべて取得する。これにはかなり時間がかかる。");
         }
-        var constructor = typeof(ccxt.bybit).GetConstructor([typeof(object)]);
-        if (constructor?.Invoke([null]) is ccxt.Exchange exchange)
+
+        if (Place.Reflection<Exchange>([null]) is Exchange exchange)
         {
             var limit = 1000;
             // 確定足情報を取得するため１分前の情報から取得していく


### PR DESCRIPTION
## 概要
`PastCandleRepository.Fetch` 実行時に `ExchangePlace.Binance` を設定していてもBybitの内容で更新されてしまうバグを修正

## 対応
リフレクションに必要な情報をAttribute内にまとめ、必要なタイミングでリフレクション可能になるように修正。
AttributeはEnumのフィールドに紐づけできるため、StrategyKindなど今後数が増える見込みの物にも適用