### PR TITLE
Feat Botの予測値と実測値をグラフに描画する

### DIFF
--- a/client/lib/application/services/bot_booter.dart
+++ b/client/lib/application/services/bot_booter.dart
@@ -1,0 +1,24 @@
+// Package imports:
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+// Project imports:
+import 'package:bot_runner/application/generated/bot.pbgrpc.dart';
+import 'package:bot_runner/infra/grpc_client.dart';
+
+part 'bot_booter.g.dart';
+
+@riverpod
+final class BotBooter extends _$BotBooter {
+  late final BotServiceClient client;
+
+  @override
+  BotBooter build() {
+    final grpc = ref.read(grpcClientProvider);
+    client = grpc.get<BotServiceClient>();
+    return this;
+  }
+
+  Stream<BotPerformance> boot(BotOrder order) {
+    return client.run(order).asBroadcastStream();
+  }
+}

--- a/client/lib/application/services/bot_booter.g.dart
+++ b/client/lib/application/services/bot_booter.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'bot_booter.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$botBooterHash() => r'0cc9c54255d1ee6ac6208dc99a124ff2d6fd6c7f';
+
+/// See also [BotBooter].
+@ProviderFor(BotBooter)
+final botBooterProvider =
+    AutoDisposeNotifierProvider<BotBooter, BotBooter>.internal(
+  BotBooter.new,
+  name: r'botBooterProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$botBooterHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$BotBooter = AutoDisposeNotifier<BotBooter>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/client/lib/application/services/routing_service.dart
+++ b/client/lib/application/services/routing_service.dart
@@ -3,9 +3,90 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+// Project imports:
+import 'package:bot_runner/application/generated/bot.pb.dart';
+
+part 'routing_service.dto.dart';
 part 'routing_service.g.dart';
 
 @riverpod
-GoRouter routingService(Ref ref) {
-  throw Exception();
+RoutingService routingService(Ref ref) {
+  throw UnimplementedError();
+}
+
+final class RoutingService {
+  final GoRouter _router;
+
+  const RoutingService(
+    GoRouter router,
+  ) : _router = router;
+
+  GoRouter get router => _router;
+
+  Future<T?> _push<T>(
+    String name, {
+    Map<String, String> pathParameter = const {},
+    Object? extra,
+  }) async {
+    return await _router.pushNamed<T>(
+      name,
+      pathParameters: pathParameter,
+      extra: extra,
+    );
+  }
+
+  Future<T?> _replace<T>(
+    String name, {
+    Map<String, String> pathParameter = const {},
+    Object? extra,
+  }) async {
+    return await _router.replaceNamed(
+      name,
+      pathParameters: pathParameter,
+      extra: extra,
+    );
+  }
+
+  void pop<T>({T? res = null}) async {
+    return _router.pop(res);
+  }
+
+  Future goToHome() async {
+    await _router.replace(RouteName.home);
+  }
+
+  Future goToBotList() async {}
+
+  Future goToBotEdit() async {
+    await _push(RouteName.botCreate);
+  }
+
+  Future goToBotDetail({
+    String id = "",
+    required Stream<BotPerformance> activities,
+    TransitionType transitionType = TransitionType.push,
+  }) async {
+    final pathParameter = {
+      "id": id,
+    };
+    return await switch (transitionType) {
+      TransitionType.push => _push(RouteName.botDetail,
+          pathParameter: pathParameter, extra: activities),
+      TransitionType.replace => _replace(RouteName.botDetail,
+          pathParameter: pathParameter, extra: activities),
+    };
+  }
+}
+
+enum TransitionType {
+  push,
+  replace,
+}
+
+final class RouteName {
+  static const String home = "home";
+  static const String botList = "bots";
+  static const String botCreate = "bot_create";
+  static const String botDetail = "bot_detail";
+  static const String featureMethodSelect = "feature_method_select";
 }

--- a/client/lib/application/services/routing_service.dart
+++ b/client/lib/application/services/routing_service.dart
@@ -1,0 +1,11 @@
+// Package imports:
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'routing_service.g.dart';
+
+@riverpod
+GoRouter routingService(Ref ref) {
+  throw Exception();
+}

--- a/client/lib/application/services/routing_service.dto.dart
+++ b/client/lib/application/services/routing_service.dto.dart
@@ -1,0 +1,27 @@
+part of 'routing_service.dart';
+
+abstract class RoutingArgs {
+  Map<String, String> get pathParameters;
+  RoutingExtraArgs get extra;
+}
+
+abstract class RoutingExtraArgs {}
+
+final class BotDetailRouteArgs extends RoutingArgs {
+  final String id;
+  final Stream<BotPerformance> activitiesStream;
+
+  BotDetailRouteArgs(this.id, this.activitiesStream);
+
+  @override
+  RoutingExtraArgs get extra => BotDetailRouteExtraArgs(activitiesStream);
+
+  @override
+  Map<String, String> get pathParameters => {"id": id};
+}
+
+final class BotDetailRouteExtraArgs extends RoutingExtraArgs {
+  final Stream<BotPerformance> activitiesStream;
+
+  BotDetailRouteExtraArgs(this.activitiesStream);
+}

--- a/client/lib/application/services/routing_service.g.dart
+++ b/client/lib/application/services/routing_service.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'routing_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$routingServiceHash() => r'f28e5b16da2505907312fce04156a71e276f87d6';
+
+/// See also [routingService].
+@ProviderFor(routingService)
+final routingServiceProvider = AutoDisposeProvider<GoRouter>.internal(
+  routingService,
+  name: r'routingServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$routingServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef RoutingServiceRef = AutoDisposeProviderRef<GoRouter>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/client/lib/application/services/routing_service.g.dart
+++ b/client/lib/application/services/routing_service.g.dart
@@ -6,11 +6,11 @@ part of 'routing_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routingServiceHash() => r'f28e5b16da2505907312fce04156a71e276f87d6';
+String _$routingServiceHash() => r'996942d50517ae2ce33dd464a252559f320bdd92';
 
 /// See also [routingService].
 @ProviderFor(routingService)
-final routingServiceProvider = AutoDisposeProvider<GoRouter>.internal(
+final routingServiceProvider = AutoDisposeProvider<RoutingService>.internal(
   routingService,
   name: r'routingServiceProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -22,6 +22,6 @@ final routingServiceProvider = AutoDisposeProvider<GoRouter>.internal(
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef RoutingServiceRef = AutoDisposeProviderRef<GoRouter>;
+typedef RoutingServiceRef = AutoDisposeProviderRef<RoutingService>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/client/lib/application/usecases/backtest_usecase.dart
+++ b/client/lib/application/usecases/backtest_usecase.dart
@@ -1,11 +1,11 @@
 // Package imports:
-import 'package:bot_runner/application/services/loading_overlay_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 // Project imports:
 import 'package:bot_runner/application/generated/bot.pb.dart';
 import 'package:bot_runner/application/services/bot_booter.dart';
+import 'package:bot_runner/application/services/loading_overlay_service.dart';
 import 'package:bot_runner/application/services/routing_service.dart';
 
 part 'backtest_usecase.g.dart';

--- a/client/lib/application/usecases/backtest_usecase.dart
+++ b/client/lib/application/usecases/backtest_usecase.dart
@@ -1,0 +1,42 @@
+// Package imports:
+import 'package:bot_runner/application/services/loading_overlay_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+// Project imports:
+import 'package:bot_runner/application/generated/bot.pb.dart';
+import 'package:bot_runner/application/services/bot_booter.dart';
+import 'package:bot_runner/application/services/routing_service.dart';
+
+part 'backtest_usecase.g.dart';
+
+@riverpod
+BacktestUsecase backtestUsecase(Ref ref) {
+  final booter = ref.read(botBooterProvider);
+  final router = ref.read(routingServiceProvider);
+  final loadingOverlay = ref.read(loadingOverlayServiceProvider.notifier);
+  return BacktestUsecase(booter, router, loadingOverlay);
+}
+
+final class BacktestUsecase {
+  final BotBooter _booter;
+  final RoutingService _router;
+  final LoadingOverlayService _loadingOverlay;
+
+  const BacktestUsecase(
+    BotBooter booter,
+    RoutingService router,
+    LoadingOverlayService loadingOverlay,
+  )   : _booter = booter,
+        _router = router,
+        _loadingOverlay = loadingOverlay;
+
+  void call(BotOrder order) async {
+    final activityStream = _booter.boot(order);
+    await _loadingOverlay.wait(() => activityStream.first);
+    await _router.goToBotDetail(
+      id: "0",
+      activities: activityStream,
+    );
+  }
+}

--- a/client/lib/application/usecases/backtest_usecase.g.dart
+++ b/client/lib/application/usecases/backtest_usecase.g.dart
@@ -6,7 +6,7 @@ part of 'backtest_usecase.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$backtestUsecaseHash() => r'a92e5e1c64853162ef4b6e6112f57d8f93bfc9eb';
+String _$backtestUsecaseHash() => r'4789bcd2a9e6458731d5922f6e285685cd37a974';
 
 /// See also [backtestUsecase].
 @ProviderFor(backtestUsecase)

--- a/client/lib/application/usecases/backtest_usecase.g.dart
+++ b/client/lib/application/usecases/backtest_usecase.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'backtest_usecase.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$backtestUsecaseHash() => r'a92e5e1c64853162ef4b6e6112f57d8f93bfc9eb';
+
+/// See also [backtestUsecase].
+@ProviderFor(backtestUsecase)
+final backtestUsecaseProvider = AutoDisposeProvider<BacktestUsecase>.internal(
+  backtestUsecase,
+  name: r'backtestUsecaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$backtestUsecaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef BacktestUsecaseRef = AutoDisposeProviderRef<BacktestUsecase>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/client/lib/infra/grpc_client.dart
+++ b/client/lib/infra/grpc_client.dart
@@ -1,6 +1,7 @@
 // Package imports:
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:grpc/grpc.dart';
+import 'package:grpc/grpc_connection_interface.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 // Project imports:
@@ -10,7 +11,7 @@ import 'package:bot_runner/application/generated/feature.pbgrpc.dart';
 
 part 'grpc_client.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 _GrpcClient grpcClient(Ref ref) {
   final grpc = _GrpcClient();
   ref.onDispose(() => grpc.shutdown());
@@ -19,6 +20,7 @@ _GrpcClient grpcClient(Ref ref) {
 
 final class _GrpcClient {
   late final ClientChannel _channel;
+  late final ClientConnection _connection;
 
   _GrpcClient({
     String host = "localhost",
@@ -31,9 +33,11 @@ final class _GrpcClient {
         credentials: ChannelCredentials.insecure(),
       ),
     );
+    _connection = _channel.createConnection();
   }
 
   Future<void> shutdown() async {
+    await _connection.shutdown();
     await _channel.shutdown();
   }
 

--- a/client/lib/infra/grpc_client.g.dart
+++ b/client/lib/infra/grpc_client.g.dart
@@ -6,11 +6,11 @@ part of 'grpc_client.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$grpcClientHash() => r'fbfcfb28f0968a39ce9230f5f8e7b28d6c0de855';
+String _$grpcClientHash() => r'cc6591cb9c204e9033e2894d9c3a83bce27fa6c4';
 
 /// See also [grpcClient].
 @ProviderFor(grpcClient)
-final grpcClientProvider = AutoDisposeProvider<_GrpcClient>.internal(
+final grpcClientProvider = Provider<_GrpcClient>.internal(
   grpcClient,
   name: r'grpcClientProvider',
   debugGetCreateSourceHash:
@@ -21,6 +21,6 @@ final grpcClientProvider = AutoDisposeProvider<_GrpcClient>.internal(
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef GrpcClientRef = AutoDisposeProviderRef<_GrpcClient>;
+typedef GrpcClientRef = ProviderRef<_GrpcClient>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -13,7 +13,7 @@ void main() {
     ProviderScope(
       child: App(),
       overrides: [
-        routingServiceProvider.overrideWith((ref) => routes),
+        routingServiceProvider.overrideWith((ref) => RoutingService(routes)),
       ],
     ),
   );
@@ -24,14 +24,14 @@ class App extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final router = ref.read(routingServiceProvider);
+    final routing = ref.read(routingServiceProvider);
     return MaterialApp.router(
       title: 'Bot runner',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      routerConfig: router,
+      routerConfig: routing.router,
     );
   }
 }

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -5,10 +5,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // Project imports:
+import 'package:bot_runner/application/services/routing_service.dart';
 import 'package:bot_runner/presentation/router.dart';
 
 void main() {
-  runApp(const ProviderScope(child: App()));
+  runApp(
+    ProviderScope(
+      child: App(),
+      overrides: [
+        routingServiceProvider.overrideWith((ref) => routes),
+      ],
+    ),
+  );
 }
 
 class App extends ConsumerWidget {
@@ -16,7 +24,7 @@ class App extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final router = ref.read(routerProvider);
+    final router = ref.read(routingServiceProvider);
     return MaterialApp.router(
       title: 'Bot runner',
       theme: ThemeData(

--- a/client/lib/presentation/bot_detail/bot_detail_page.dart
+++ b/client/lib/presentation/bot_detail/bot_detail_page.dart
@@ -1,12 +1,43 @@
+// Dart imports:
+import 'dart:async';
+
 // Flutter imports:
+import 'package:bot_runner/application/services/loading_overlay_service.dart';
 import 'package:flutter/material.dart';
 
-class BotDeatilPage extends StatelessWidget {
-  const BotDeatilPage({super.key});
+// Package imports:
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+// Project imports:
+import 'package:bot_runner/application/generated/bot.pb.dart';
+import 'package:bot_runner/presentation/widgets/bot_activity_chart.dart';
+
+part 'bot_detail_page.state.dart';
+part 'bot_detail_page.notifier.dart';
+part 'bot_detail_page.g.dart';
+part 'bot_detail_page.freezed.dart';
+
+final class BotDeatilPage extends ConsumerWidget {
+  late final BotDetailPageNotifierProvider _provider;
+
+  BotDeatilPage({
+    super.key,
+    required Stream<BotPerformance> activities,
+  }) {
+    _provider = BotDetailPageNotifierProvider(activities);
+  }
 
   @override
-  Widget build(BuildContext context) {
-    // TODO: implement build
-    throw UnimplementedError();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifer = ref.read(_provider.notifier);
+    final state = ref.watch(_provider);
+    return Scaffold(
+      appBar: AppBar(),
+      body: BotActivityChart(
+        data: state.activities,
+      ),
+    );
   }
 }

--- a/client/lib/presentation/bot_detail/bot_detail_page.dart
+++ b/client/lib/presentation/bot_detail/bot_detail_page.dart
@@ -2,7 +2,6 @@
 import 'dart:async';
 
 // Flutter imports:
-import 'package:bot_runner/application/services/loading_overlay_service.dart';
 import 'package:flutter/material.dart';
 
 // Package imports:
@@ -12,6 +11,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 // Project imports:
 import 'package:bot_runner/application/generated/bot.pb.dart';
+import 'package:bot_runner/application/services/loading_overlay_service.dart';
 import 'package:bot_runner/presentation/widgets/bot_activity_chart.dart';
 
 part 'bot_detail_page.state.dart';
@@ -36,7 +36,7 @@ final class BotDeatilPage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(),
       body: BotActivityChart(
-        data: state.activities,
+        performances: state.activities,
       ),
     );
   }

--- a/client/lib/presentation/bot_detail/bot_detail_page.freezed.dart
+++ b/client/lib/presentation/bot_detail/bot_detail_page.freezed.dart
@@ -1,0 +1,155 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'bot_detail_page.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$BotDetailPageState {
+  List<BotPerformance> get activities => throw _privateConstructorUsedError;
+
+  /// Create a copy of BotDetailPageState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $BotDetailPageStateCopyWith<BotDetailPageState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BotDetailPageStateCopyWith<$Res> {
+  factory $BotDetailPageStateCopyWith(
+          BotDetailPageState value, $Res Function(BotDetailPageState) then) =
+      _$BotDetailPageStateCopyWithImpl<$Res, BotDetailPageState>;
+  @useResult
+  $Res call({List<BotPerformance> activities});
+}
+
+/// @nodoc
+class _$BotDetailPageStateCopyWithImpl<$Res, $Val extends BotDetailPageState>
+    implements $BotDetailPageStateCopyWith<$Res> {
+  _$BotDetailPageStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of BotDetailPageState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? activities = null,
+  }) {
+    return _then(_value.copyWith(
+      activities: null == activities
+          ? _value.activities
+          : activities // ignore: cast_nullable_to_non_nullable
+              as List<BotPerformance>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$BotDetailPageStateImplCopyWith<$Res>
+    implements $BotDetailPageStateCopyWith<$Res> {
+  factory _$$BotDetailPageStateImplCopyWith(_$BotDetailPageStateImpl value,
+          $Res Function(_$BotDetailPageStateImpl) then) =
+      __$$BotDetailPageStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<BotPerformance> activities});
+}
+
+/// @nodoc
+class __$$BotDetailPageStateImplCopyWithImpl<$Res>
+    extends _$BotDetailPageStateCopyWithImpl<$Res, _$BotDetailPageStateImpl>
+    implements _$$BotDetailPageStateImplCopyWith<$Res> {
+  __$$BotDetailPageStateImplCopyWithImpl(_$BotDetailPageStateImpl _value,
+      $Res Function(_$BotDetailPageStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of BotDetailPageState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? activities = null,
+  }) {
+    return _then(_$BotDetailPageStateImpl(
+      activities: null == activities
+          ? _value._activities
+          : activities // ignore: cast_nullable_to_non_nullable
+              as List<BotPerformance>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BotDetailPageStateImpl implements _BotDetailPageState {
+  const _$BotDetailPageStateImpl(
+      {final List<BotPerformance> activities = const []})
+      : _activities = activities;
+
+  final List<BotPerformance> _activities;
+  @override
+  @JsonKey()
+  List<BotPerformance> get activities {
+    if (_activities is EqualUnmodifiableListView) return _activities;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_activities);
+  }
+
+  @override
+  String toString() {
+    return 'BotDetailPageState(activities: $activities)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BotDetailPageStateImpl &&
+            const DeepCollectionEquality()
+                .equals(other._activities, _activities));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_activities));
+
+  /// Create a copy of BotDetailPageState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BotDetailPageStateImplCopyWith<_$BotDetailPageStateImpl> get copyWith =>
+      __$$BotDetailPageStateImplCopyWithImpl<_$BotDetailPageStateImpl>(
+          this, _$identity);
+}
+
+abstract class _BotDetailPageState implements BotDetailPageState {
+  const factory _BotDetailPageState({final List<BotPerformance> activities}) =
+      _$BotDetailPageStateImpl;
+
+  @override
+  List<BotPerformance> get activities;
+
+  /// Create a copy of BotDetailPageState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$BotDetailPageStateImplCopyWith<_$BotDetailPageStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/client/lib/presentation/bot_detail/bot_detail_page.g.dart
+++ b/client/lib/presentation/bot_detail/bot_detail_page.g.dart
@@ -7,7 +7,7 @@ part of 'bot_detail_page.dart';
 // **************************************************************************
 
 String _$botDetailPageNotifierHash() =>
-    r'34677bf4d182862c3595a5915b956078c087bff6';
+    r'0a8967ab2fa4fc7aada2945dbcbae61dac6c9ad2';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/client/lib/presentation/bot_detail/bot_detail_page.g.dart
+++ b/client/lib/presentation/bot_detail/bot_detail_page.g.dart
@@ -1,0 +1,180 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'bot_detail_page.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$botDetailPageNotifierHash() =>
+    r'34677bf4d182862c3595a5915b956078c087bff6';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$BotDetailPageNotifier
+    extends BuildlessAutoDisposeNotifier<BotDetailPageState> {
+  late final Stream<BotPerformance> activities;
+
+  BotDetailPageState build(
+    Stream<BotPerformance> activities,
+  );
+}
+
+/// See also [BotDetailPageNotifier].
+@ProviderFor(BotDetailPageNotifier)
+const botDetailPageNotifierProvider = BotDetailPageNotifierFamily();
+
+/// See also [BotDetailPageNotifier].
+class BotDetailPageNotifierFamily extends Family<BotDetailPageState> {
+  /// See also [BotDetailPageNotifier].
+  const BotDetailPageNotifierFamily();
+
+  /// See also [BotDetailPageNotifier].
+  BotDetailPageNotifierProvider call(
+    Stream<BotPerformance> activities,
+  ) {
+    return BotDetailPageNotifierProvider(
+      activities,
+    );
+  }
+
+  @override
+  BotDetailPageNotifierProvider getProviderOverride(
+    covariant BotDetailPageNotifierProvider provider,
+  ) {
+    return call(
+      provider.activities,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'botDetailPageNotifierProvider';
+}
+
+/// See also [BotDetailPageNotifier].
+class BotDetailPageNotifierProvider extends AutoDisposeNotifierProviderImpl<
+    BotDetailPageNotifier, BotDetailPageState> {
+  /// See also [BotDetailPageNotifier].
+  BotDetailPageNotifierProvider(
+    Stream<BotPerformance> activities,
+  ) : this._internal(
+          () => BotDetailPageNotifier()..activities = activities,
+          from: botDetailPageNotifierProvider,
+          name: r'botDetailPageNotifierProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$botDetailPageNotifierHash,
+          dependencies: BotDetailPageNotifierFamily._dependencies,
+          allTransitiveDependencies:
+              BotDetailPageNotifierFamily._allTransitiveDependencies,
+          activities: activities,
+        );
+
+  BotDetailPageNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.activities,
+  }) : super.internal();
+
+  final Stream<BotPerformance> activities;
+
+  @override
+  BotDetailPageState runNotifierBuild(
+    covariant BotDetailPageNotifier notifier,
+  ) {
+    return notifier.build(
+      activities,
+    );
+  }
+
+  @override
+  Override overrideWith(BotDetailPageNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: BotDetailPageNotifierProvider._internal(
+        () => create()..activities = activities,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        activities: activities,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<BotDetailPageNotifier, BotDetailPageState>
+      createElement() {
+    return _BotDetailPageNotifierProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BotDetailPageNotifierProvider &&
+        other.activities == activities;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, activities.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin BotDetailPageNotifierRef
+    on AutoDisposeNotifierProviderRef<BotDetailPageState> {
+  /// The parameter `activities` of this provider.
+  Stream<BotPerformance> get activities;
+}
+
+class _BotDetailPageNotifierProviderElement
+    extends AutoDisposeNotifierProviderElement<BotDetailPageNotifier,
+        BotDetailPageState> with BotDetailPageNotifierRef {
+  _BotDetailPageNotifierProviderElement(super.provider);
+
+  @override
+  Stream<BotPerformance> get activities =>
+      (origin as BotDetailPageNotifierProvider).activities;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/client/lib/presentation/bot_detail/bot_detail_page.notifier.dart
+++ b/client/lib/presentation/bot_detail/bot_detail_page.notifier.dart
@@ -7,8 +7,8 @@ class BotDetailPageNotifier extends _$BotDetailPageNotifier {
     activities.listen(
       (e) {
         final fixed = [...state.activities, e];
-        if (10000 < fixed.length) {
-          fixed.removeRange(0, fixed.length - 10000);
+        if (1000 < fixed.length) {
+          fixed.removeRange(0, fixed.length - 1000);
         }
         state = state.copyWith(activities: fixed);
       },

--- a/client/lib/presentation/bot_detail/bot_detail_page.notifier.dart
+++ b/client/lib/presentation/bot_detail/bot_detail_page.notifier.dart
@@ -1,0 +1,18 @@
+part of 'bot_detail_page.dart';
+
+@riverpod
+class BotDetailPageNotifier extends _$BotDetailPageNotifier {
+  @override
+  BotDetailPageState build(Stream<BotPerformance> activities) {
+    activities.listen(
+      (e) {
+        final fixed = [...state.activities, e];
+        if (10000 < fixed.length) {
+          fixed.removeRange(0, fixed.length - 10000);
+        }
+        state = state.copyWith(activities: fixed);
+      },
+    );
+    return BotDetailPageState();
+  }
+}

--- a/client/lib/presentation/bot_detail/bot_detail_page.state.dart
+++ b/client/lib/presentation/bot_detail/bot_detail_page.state.dart
@@ -1,0 +1,8 @@
+part of 'bot_detail_page.dart';
+
+@freezed
+class BotDetailPageState with _$BotDetailPageState {
+  const factory BotDetailPageState({
+    @Default([]) List<BotPerformance> activities,
+  }) = _BotDetailPageState;
+}

--- a/client/lib/presentation/bot_edit/bot_edit_page.dart
+++ b/client/lib/presentation/bot_edit/bot_edit_page.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 
 // Package imports:
+import 'package:fixnum/fixnum.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -9,6 +10,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 // Project imports:
 import 'package:bot_runner/application/generated/bot.pb.dart';
+import 'package:bot_runner/application/generated/exchange.pb.dart' as grpc;
+import 'package:bot_runner/application/generated/google/protobuf/timestamp.pb.dart';
+import 'package:bot_runner/application/usecases/backtest_usecase.dart';
 import 'package:bot_runner/presentation/widgets/form/bot_edit_form.dart';
 
 part 'bot_edit_page.state.dart';
@@ -35,7 +39,7 @@ class BotEditPage extends ConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         child: Icon(Icons.start),
-        onPressed: () {}, //TODO
+        onPressed: notifier.onEditComfirm
       ),
     );
   }

--- a/client/lib/presentation/bot_edit/bot_edit_page.g.dart
+++ b/client/lib/presentation/bot_edit/bot_edit_page.g.dart
@@ -7,7 +7,7 @@ part of 'bot_edit_page.dart';
 // **************************************************************************
 
 String _$botEditPageNotifierHash() =>
-    r'c5a819201c135b36791f3ec679c1747ecb23f751';
+    r'08160f180f0d20a252816676353b9140f368448b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/client/lib/presentation/bot_edit/bot_edit_page.notifier.dart
+++ b/client/lib/presentation/bot_edit/bot_edit_page.notifier.dart
@@ -9,4 +9,27 @@ class BotEditPageNotifier extends _$BotEditPageNotifier {
       order: order,
     );
   }
+
+  void onEditComfirm() {
+    final startAt = Timestamp(
+      seconds: Int64(DateTime.utc(2020).millisecondsSinceEpoch ~/ 1000),
+    );
+    final endAt = Timestamp(
+      seconds: Int64(DateTime.utc(2024).millisecondsSinceEpoch ~/ 1000),
+    );
+    final usecase = ref.read(backtestUsecaseProvider);
+    final order = BotOrder(
+      symbol: grpc.Symbol(
+        code: "BTCUSDT",
+        name: "",
+        place: grpc.ExchangePlace(
+          name: "Bybit",
+          isBacktest: true,
+        ),
+      ),
+      startAt: startAt,
+      endAt: endAt,
+    );
+    usecase.call(order);
+  }
 }

--- a/client/lib/presentation/feature_method_select/feature_method_select_dialog_page_notifier.dart
+++ b/client/lib/presentation/feature_method_select/feature_method_select_dialog_page_notifier.dart
@@ -1,6 +1,8 @@
 // Package imports:
-import 'package:bot_runner/application/services/routing_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+// Project imports:
+import 'package:bot_runner/application/services/routing_service.dart';
 
 part 'feature_method_select_dialog_page_notifier.g.dart';
 
@@ -17,7 +19,7 @@ class FeatureMethodSelectDialogPageNotifier
   }
 
   void onConfirmed() {
-    ref.read(routingServiceProvider).pop(state);
+    ref.read(routingServiceProvider).pop(res: state);
   }
 
   void onCanceled() {

--- a/client/lib/presentation/feature_method_select/feature_method_select_dialog_page_notifier.dart
+++ b/client/lib/presentation/feature_method_select/feature_method_select_dialog_page_notifier.dart
@@ -1,8 +1,6 @@
 // Package imports:
+import 'package:bot_runner/application/services/routing_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-// Project imports:
-import 'package:bot_runner/presentation/router.dart';
 
 part 'feature_method_select_dialog_page_notifier.g.dart';
 
@@ -19,10 +17,10 @@ class FeatureMethodSelectDialogPageNotifier
   }
 
   void onConfirmed() {
-    ref.read(routerProvider).pop(state);
+    ref.read(routingServiceProvider).pop(state);
   }
 
   void onCanceled() {
-    ref.read(routerProvider).pop();
+    ref.read(routingServiceProvider).pop();
   }
 }

--- a/client/lib/presentation/feature_method_select/feature_method_select_dialog_page_notifier.g.dart
+++ b/client/lib/presentation/feature_method_select/feature_method_select_dialog_page_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'feature_method_select_dialog_page_notifier.dart';
 // **************************************************************************
 
 String _$featureMethodSelectDialogPageNotifierHash() =>
-    r'88f5d26327f1637ff3b0e319498126695e3b0ef6';
+    r'517f46bf05d97f96d3558b7bfd5a2ad2078f1ef4';
 
 /// See also [FeatureMethodSelectDialogPageNotifier].
 @ProviderFor(FeatureMethodSelectDialogPageNotifier)

--- a/client/lib/presentation/home/home_page_notifier.dart
+++ b/client/lib/presentation/home/home_page_notifier.dart
@@ -1,8 +1,6 @@
 // Package imports:
+import 'package:bot_runner/application/services/routing_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-// Project imports:
-import 'package:bot_runner/presentation/router.dart';
 
 part 'home_page_notifier.g.dart';
 
@@ -14,6 +12,6 @@ class HomePageNotifier extends _$HomePageNotifier {
   }
 
   void pushBotCreatePage() {
-    ref.read(routerProvider).push("/bots/create");
+    ref.read(routingServiceProvider).push("/bots/create");
   }
 }

--- a/client/lib/presentation/home/home_page_notifier.dart
+++ b/client/lib/presentation/home/home_page_notifier.dart
@@ -1,6 +1,8 @@
 // Package imports:
-import 'package:bot_runner/application/services/routing_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+// Project imports:
+import 'package:bot_runner/application/services/routing_service.dart';
 
 part 'home_page_notifier.g.dart';
 
@@ -12,6 +14,6 @@ class HomePageNotifier extends _$HomePageNotifier {
   }
 
   void pushBotCreatePage() {
-    ref.read(routingServiceProvider).push("/bots/create");
+    ref.read(routingServiceProvider).goToBotEdit();
   }
 }

--- a/client/lib/presentation/home/home_page_notifier.g.dart
+++ b/client/lib/presentation/home/home_page_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'home_page_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$homePageNotifierHash() => r'08cff3c756894ad9e05ab00e85a630f768e3eb82';
+String _$homePageNotifierHash() => r'df725f2ac20b965255c595727a8beec6de8392b0';
 
 /// See also [HomePageNotifier].
 @ProviderFor(HomePageNotifier)

--- a/client/lib/presentation/router.dart
+++ b/client/lib/presentation/router.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 // Project imports:
+import 'package:bot_runner/application/generated/bot.pb.dart';
+import 'package:bot_runner/application/services/routing_service.dart';
 import 'package:bot_runner/presentation/bot_detail/bot_detail_page.dart';
 import 'package:bot_runner/presentation/bot_edit/bot_edit_page.dart';
 import 'package:bot_runner/presentation/bot_list/bot_list_page.dart';
@@ -22,7 +24,7 @@ final routes = GoRouter(
 
 @TypedGoRoute<HomeRoute>(
   path: "/",
-  name: "home",
+  name: RouteName.home,
 )
 final class HomeRoute extends GoRouteData {
   const HomeRoute();
@@ -37,25 +39,21 @@ final class HomeRoute extends GoRouteData {
 
 @TypedGoRoute<BotRoute>(
   path: "/bots",
-  name: "bots",
+  name: RouteName.botList,
   routes: [
     TypedGoRoute<BotCreateRoute>(
       path: "/create",
-      name: "bot_create",
+      name: RouteName.botCreate,
       routes: [
         TypedGoRoute<FeatureMethodSelectRoute>(
           path: "/features/select",
-          name: "feature_method_select",
+          name: RouteName.featureMethodSelect,
         ),
       ],
     ),
     TypedGoRoute<BotDetailRoute>(
       path: "/:id",
-      name: "bot_detail",
-    ),
-    TypedGoRoute<BotEditRoute>(
-      path: "/:id/edit",
-      name: "bot_edit",
+      name: RouteName.botDetail,
     ),
   ],
 )
@@ -79,8 +77,9 @@ final class BotDetailRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const LoadingOverlay(
-      child: BotDeatilPage(),
+    final i = state.extra as Stream<BotPerformance>;
+    return LoadingOverlay(
+      child: BotDeatilPage(activities: i),
     );
   }
 }

--- a/client/lib/presentation/router.dart
+++ b/client/lib/presentation/router.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:go_router/go_router.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 // Project imports:
 import 'package:bot_runner/presentation/bot_detail/bot_detail_page.dart';
@@ -16,12 +15,10 @@ import 'package:bot_runner/presentation/widgets/loading_overlay.dart';
 part 'router.g.dart';
 part 'router.dialog.dart';
 
-final routerProvider = Provider((ref) {
-  return GoRouter(
-    initialLocation: "/",
-    routes: $appRoutes,
-  );
-});
+final routes = GoRouter(
+  routes: $appRoutes,
+  initialLocation: "/",
+);
 
 @TypedGoRoute<HomeRoute>(
   path: "/",

--- a/client/lib/presentation/router.g.dart
+++ b/client/lib/presentation/router.g.dart
@@ -56,11 +56,6 @@ RouteBase get $botRoute => GoRouteData.$route(
           name: 'bot_detail',
           factory: $BotDetailRouteExtension._fromState,
         ),
-        GoRouteData.$route(
-          path: '/:id/edit',
-          name: 'bot_edit',
-          factory: $BotEditRouteExtension._fromState,
-        ),
       ],
     );
 
@@ -123,25 +118,6 @@ extension $BotDetailRouteExtension on BotDetailRoute {
 
   String get location => GoRouteData.$location(
         '/${Uri.encodeComponent(id)}',
-      );
-
-  void go(BuildContext context) => context.go(location);
-
-  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
-
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
-
-  void replace(BuildContext context) => context.replace(location);
-}
-
-extension $BotEditRouteExtension on BotEditRoute {
-  static BotEditRoute _fromState(GoRouterState state) => BotEditRoute(
-        id: state.pathParameters['id']!,
-      );
-
-  String get location => GoRouteData.$location(
-        '/${Uri.encodeComponent(id)}/edit',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/client/lib/presentation/widgets/bot_activity_chart.dart
+++ b/client/lib/presentation/widgets/bot_activity_chart.dart
@@ -1,0 +1,40 @@
+import 'package:bot_runner/application/generated/bot.pb.dart';
+import 'package:flutter/material.dart';
+import 'package:graphic/graphic.dart';
+
+final class BotActivityChart extends Chart<BotPerformance> {
+  BotActivityChart({
+    required super.data,
+  }) : super(
+          variables: {
+            "time": Variable<BotPerformance, DateTime>(
+              accessor: (p0) => p0.timestamp.toDateTime(),
+              scale: TimeScale(
+                title: "time",
+              ),
+            ),
+            "actual": Variable<BotPerformance, double>(
+              accessor: (p0) => p0.actualValue,
+            ),
+            "predicate": Variable<BotPerformance, double>(
+              accessor: (p0) => p0.predictValue,
+            ),
+          },
+          marks: [
+            LineMark(
+                position: Varset("time") * Varset("actual"),
+                color: ColorEncode(
+                  value: Colors.grey,
+                )),
+            LineMark(
+                position: Varset("time") * Varset("predicate"),
+                color: ColorEncode(
+                  value: Colors.blue,
+                )),
+          ],
+          axes: [
+            Defaults.verticalAxis,
+            Defaults.horizontalAxis,
+          ],
+        );
+}

--- a/client/lib/presentation/widgets/bot_activity_chart.dart
+++ b/client/lib/presentation/widgets/bot_activity_chart.dart
@@ -1,6 +1,11 @@
-import 'package:bot_runner/application/generated/bot.pb.dart';
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:graphic/graphic.dart';
+
+// Project imports:
+import 'package:bot_runner/application/generated/bot.pb.dart';
 
 final class BotActivityChart extends Chart<BotPerformance> {
   BotActivityChart({

--- a/client/lib/presentation/widgets/bot_activity_chart.dart
+++ b/client/lib/presentation/widgets/bot_activity_chart.dart
@@ -2,44 +2,71 @@
 import 'package:flutter/material.dart';
 
 // Package imports:
-import 'package:graphic/graphic.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:intl/intl.dart';
 
 // Project imports:
 import 'package:bot_runner/application/generated/bot.pb.dart';
 
-final class BotActivityChart extends Chart<BotPerformance> {
-  BotActivityChart({
-    required super.data,
-  }) : super(
-          variables: {
-            "time": Variable<BotPerformance, DateTime>(
-              accessor: (p0) => p0.timestamp.toDateTime(),
-              scale: TimeScale(
-                title: "time",
-              ),
+final class BotActivityChart extends StatelessWidget {
+  final List<BotPerformance> performances;
+
+  const BotActivityChart({
+    required this.performances,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LineChart(
+      LineChartData(
+        lineBarsData: [
+          LineChartBarData(
+            spots: performances.map((e) {
+              return FlSpot(e.timestamp.seconds.toDouble(), e.actualValue);
+            }).toList(),
+            isCurved: true,
+            color: Colors.grey,
+            dotData: FlDotData(
+              show: false,
             ),
-            "actual": Variable<BotPerformance, double>(
-              accessor: (p0) => p0.actualValue,
+          ),
+          LineChartBarData(
+            spots: performances.map((e) {
+              return FlSpot(e.timestamp.seconds.toDouble(), e.predictValue);
+            }).toList(),
+            isCurved: true,
+            color: Colors.blue,
+            dotData: FlDotData(
+              show: false,
             ),
-            "predicate": Variable<BotPerformance, double>(
-              accessor: (p0) => p0.predictValue,
+          ),
+        ],
+        titlesData: FlTitlesData(
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: false,
             ),
-          },
-          marks: [
-            LineMark(
-                position: Varset("time") * Varset("actual"),
-                color: ColorEncode(
-                  value: Colors.grey,
-                )),
-            LineMark(
-                position: Varset("time") * Varset("predicate"),
-                color: ColorEncode(
-                  value: Colors.blue,
-                )),
-          ],
-          axes: [
-            Defaults.verticalAxis,
-            Defaults.horizontalAxis,
-          ],
-        );
+          ),
+          topTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: false,
+            ),
+          ),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 32,
+              getTitlesWidget: (value, meta) {
+                final date =
+                    DateTime.fromMillisecondsSinceEpoch(value.toInt() * 1000);
+                final formated = DateFormat('MM/dd HH:mm').format(date);
+                return Text(formated);
+              },
+              interval: 3600,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -238,6 +238,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -262,6 +270,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "74959b99b92b9eebeed1a4049426fd67c4abc3c5a0f4d12e2877097d6a11ae08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.69.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -451,7 +451,7 @@ packages:
     source: hosted
     version: "4.6.0"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   import_sorter: ^4.6.0
   protobuf: ^3.1.0
   grpc: ^4.0.1
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   protobuf: ^3.1.0
   grpc: ^4.0.1
   intl: ^0.19.0
+  fl_chart: ^0.69.2
 
 dev_dependencies:
   flutter_test:

--- a/server/src/Interface/Program.cs
+++ b/server/src/Interface/Program.cs
@@ -15,7 +15,7 @@ public class Program
     {
         Domain.Python.Setup();
 
-        var connectionFactory = new OrmLiteConnectionFactory("/workspaces/trade_bot/server/data/ohlcvs.sqlite3", SqliteDialect.Provider);
+        var connectionFactory = new OrmLiteConnectionFactory("/workspaces/BotTradeFramework/server/data/ohlcvs.sqlite3", SqliteDialect.Provider);
         await DatabaseStarter.CreateTables(connectionFactory);
 
         var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
## 概要
Bot作成後、詳細画面で予測と実測のグラフを描画するように対応。

グラフ描画には元々入れていたgraphsパッケージでは描画パフォーマンスが悪かったため、fl_chartを導入して実装。
グレーが実測値、青が予測値